### PR TITLE
chore(submodule): move Memfault SDK to components

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "src/memfault/memfault-firmware-sdk"]
-	path = src/memfault/memfault-firmware-sdk
+	path = components/memfault-firmware-sdk
 	url = https://github.com/memfault/memfault-firmware-sdk.git
-	branch = 1.6.2+platformio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # is named 'main', so we need to change from the default to 'src'
 set(MEMFAULT_PLATFORM_PORT_COMPONENTS src)
 
-set(MEMFAULT_FIRMWARE_SDK src/memfault/memfault-firmware-sdk)
+set(MEMFAULT_FIRMWARE_SDK components/memfault-firmware-sdk)
 include(${MEMFAULT_FIRMWARE_SDK}/ports/esp_idf/memfault.cmake)
 
 cmake_minimum_required(VERSION 3.16.0)

--- a/add_build_id.py
+++ b/add_build_id.py
@@ -10,7 +10,7 @@ env.AddPostAction(
         " ".join(
             [
                 "$PYTHONEXE",
-                "$PROJECT_DIR/src/memfault/memfault-firmware-sdk/scripts/fw_build_id.py",
+                "$PROJECT_DIR/components/memfault-firmware-sdk/scripts/fw_build_id.py",
                 "$BUILD_DIR/${PROGNAME}.elf",
             ]
         ),

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ board_build.cmake_extra_args =
 
 ; add linker fragment needed for ESP-IDF projects
 board_build.esp-idf.extra_lf_files =
-  src/memfault/memfault-firmware-sdk/ports/esp_idf/memfault/common/memfault_esp_freertos.lf
+  components/memfault-firmware-sdk/ports/esp_idf/memfault/common/memfault_esp_freertos.lf
 
 ; add coredump flash partition
 board_build.partitions = partitions_example.csv
@@ -40,8 +40,8 @@ monitor_speed = 115200
 ; manually include the freertos_trace.h
 build_flags =
   -Isrc/memfault
-  -Isrc/memfault/memfault-firmware-sdk/components/include
-  -include src/memfault/memfault-firmware-sdk/ports/include/memfault/ports/freertos_trace.h
+  -Icomponents/memfault-firmware-sdk/components/include
+  -include components/memfault-firmware-sdk/ports/include/memfault/ports/freertos_trace.h
 
 
 [platformio]


### PR DESCRIPTION
### Summary

To align with [our PlatformIO integration guide](https://docs.memfault.com/docs/mcu/platformio-esp-idf-guide#clone-memfault-sdk),
the Memfault SDK  is now in `components/` instead of
`src/memfault/`.

Involved moving the submodule with:

```
git mv src/memfault/memfault-firmware-sdk components/memfault-firmware-sdk
```

Also, removed the specific branch from the `.gitmodules`
file for the sdk since those changes are now on `master`.

### Test Plan

Compiled and flashed ESP32-C3:

```
pio run
pio run --target upload --target monitor
```
