### PR TITLE
chore: fix platformio build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install PlatformIO
         run: |
-          pip install platformio==6.1.13
+          pip install platformio==6.1.15
 
       - name: Build
         run: |
-          pio run
+          pio run --verbose

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,14 +18,21 @@ board = esp32-c3-devkitc-02
 
 ; Strictly specify the versions used to build this project
 platform_packages =
-  framework-espidf@3.50102.240122  ; (5.1.2)
-  tool-cmake@3.16.4
-  tool-esptoolpy@1.40501.0  ; (4.5.1)
-  tool-ninja@1.7.1
+  platformio/framework-espidf@3.50300.0  ; (5.3.0)
+  platformio/tool-cmake@3.16.4
+  platformio/tool-esptoolpy@1.40501.0  ; (4.5.1)
   espressif/tool-riscv32-esp-elf-gdb@12.1.0+20221002
   espressif/tool-xtensa-esp-elf-gdb@12.1.0+20221002
-  platformio/toolchain-esp32ulp@1.23500.220830  ; (2.35.0)
-  espressif/toolchain-riscv32-esp@12.2.0+20230208
+  platformio/toolchain-esp32ulp@1.23800.240113  ; (2.38.0)
+  platformio/toolchain-riscv32-esp@13.2.0+20240530
+
+  ; The tools-ninja package does not have a version compatible with
+  ; both Linux and MacOS so skip adding it to the platform_packages,
+  ; but note the versions below should be picked up by each.
+  ; See https://registry.platformio.org/tools/platformio/tool-ninja
+  ; for versions and compatibility.
+  ; platformio/tool-ninja@1.7.1 ; compatible with Linux
+  ; platformio/tool-ninja@1.9.0 ; compatible with MacOS
 
 ; needed to tell Memfault that we are using a platformIO project
 board_build.cmake_extra_args =


### PR DESCRIPTION
### Summary

 The build has been broken for sometime now due to an issue including
 components needed for the build. Locally, the error shows up as:

```
CMake Error: Error processing file: /Users/gminnehan/projects/platformio-esp32-espidf/.pio/build/espidf/esp-idf/esp_system/ld/linker_script_generator.cmake
Retrieved `.pio/build/espidf/app_trace/app_trace_util.c.o' from cache
*** [.pio/build/espidf/esp-idf/esp_system/ld/sections.ld.in] Error 1
src/led.c:19:12: fatal error: led_strip.h: No such file or directory

   19 |   #include "led_strip.h"
      |            ^~~~~~~~~~~~~
compilation terminated.
*** [.pio/build/espidf/src/led.c.o] Error 1
```

This PR fixes the build by
 upgrading the PlatformIO core and its dependencies.

A few other notes:
- I was getting some strange errors when building with the
`espressif/toolchain-riscv32-esp` but
`platformio/toolchain-riscv32-esp` worked just fine, so I
switched over 🤷‍♀️ 
- Unfortunately there isn't a version of `tool-ninja` package that
has support for both Linux and MacOS, so specifying the 
wrong version of this package breaks the build 🫠 :

   ```
    Tool Manager: Installing platformio/tool-ninja @ 1.7.1
   UnknownPackageError: Could not find the package with 
   'platformio/tool-ninja @ 1.7.1' requirements for your system 
   'darwin_arm64'
   ```

   I couldn't find an easy way to conditionally include packages in
the `platformio.ini` so I've removed that version pin and added a
comment.

 The original CI logs were [pretty unhelpful](https://github.com/memfault/platformio-esp32-espidf/actions/runs/10960960920/job/30436791360#step:5:182)
 so I've also added the `--verbose` flag to the build command.

 ### Test Plan

CI

---
Resolves: MCU-677