### PR TITLE
Bump to 3.50301.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,8 +18,8 @@ board = esp32-c3-devkitc-02
 
 ; Strictly specify the versions used to build this project
 platform_packages =
-  platformio/framework-espidf@3.50300.0  ; (5.3.0)
-  platformio/tool-cmake@3.16.4
+  platformio/framework-espidf@3.50301.0  ; (5.3.1)
+  platformio/tool-cmake@3.21.3
   platformio/tool-esptoolpy@1.40501.0  ; (4.5.1)
   espressif/tool-riscv32-esp-elf-gdb@12.1.0+20221002
   espressif/tool-xtensa-esp-elf-gdb@12.1.0+20221002


### PR DESCRIPTION
Effectively 5.3.0 -> 5.3.1.

This appears to resolve my local build error due to failure to
pre-process sections.ld:

```plaintext
/opt/platformio/packages/toolchain-riscv32-esp/bin/../lib/gcc/riscv32-esp-elf/13.2.0/../../../../riscv32-esp-elf/bin/ld:sections.ld:541
```

I don't see any note about changes in the upstream release notes:
https://github.com/espressif/esp-idf/releases/tag/v5.3.1

I'm guessing some platformio goof? not worth debugging imo.