### PR TITLE
Update Memfault dependencies installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ source ~/.platformio/penv/bin/activate
 4. Install Memfault's dependencies
 
 ```bash
-pip install -r src/memfault/memfault-firmware-sdk/requirements.txt
+pip install -r third-party/memfault-firmware-sdk/requirements.txt
 pip install memfault-cli
 ```
 


### PR DESCRIPTION
After moving the Memfault SDK submodule, the doc referred to the old location